### PR TITLE
update site content to match current codebase state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,12 @@ legionio.dev/
 | Home | `index.md` | 1 | All visitors |
 | Philosophy | `philosophy.md` | 2 | All visitors |
 | Architecture | `architecture.md` | 3 | Developers |
-| Enterprise | `enterprise.md` | 4 | Enterprise users |
-| Settings Reference | `settings.md` | 4 | Operators, developers |
+| LLM Pipeline | `pipeline.md` | 4 | Developers |
 | Extensions | `extensions.md` | 5 | Extension authors |
 | Compatibility | `compatibility.md` | 6 | Integrators |
 | Getting Started | `getting-started/` | 7 | New users |
+| Enterprise | `enterprise.md` | 8 | Enterprise users |
+| Settings Reference | `settings.md` | 9 | Operators, developers |
 
 ## Development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,47 +1,65 @@
-# docs-site: LegionIO Documentation Website
+# legionio.dev: LegionIO Documentation Website
 
 **Repository Level 3 Documentation**
 - **Parent**: `/Users/miverso2/rubymine/legion/CLAUDE.md`
 
 ## Purpose
 
-The public-facing documentation website for LegionIO, built with Jekyll and served via GitHub Pages. Contains architecture guides, getting-started content, extension development documentation, compatibility tables, and the project philosophy.
+The public-facing documentation website for LegionIO, built with Jekyll and served via GitHub Pages. Contains architecture guides, getting-started content, extension development documentation, compatibility tables, settings reference, and the project philosophy.
 
-**GitHub**: https://github.com/LegionIO/docs-site
+**GitHub**: https://github.com/LegionIO/legionio.dev
 **Live site**: https://legionio.dev (CNAME configured)
 
 ## Directory Structure
 
 ```
-docs-site/
-├── _config.yml           # Jekyll configuration (theme: just-the-docs)
-├── _includes/            # Shared partials (header, footer, nav)
-├── _site/                # Generated output (do not edit, git-ignored)
-├── assets/               # Static assets (CSS, JS, images, visualization.html)
-├── getting-started/      # Getting-started guides (quickstart-agent.md, etc.)
-├── index.md              # Home page (hero section, install, quick links)
-├── architecture.md       # Architecture deep-dive
-├── philosophy.md         # Project philosophy
-├── extensions.md         # Extension ecosystem overview
-├── compatibility.md      # Ruby version and gem compatibility matrix
-├── enterprise.md         # Enterprise features and deployment guide
-├── schema.md             # Settings JSON schema reference
-├── CNAME                 # GitHub Pages custom domain
-├── Gemfile               # Jekyll + just-the-docs
-└── Gemfile.lock
+legionio.dev/
+├── _config.yml              # Jekyll configuration (theme: just-the-docs, dark mode)
+├── _includes/
+│   └── head_custom.html     # OG meta tags, Twitter cards, hero CSS, favicon link
+├── _site/                   # Generated output (git-ignored, do not edit)
+├── assets/
+│   ├── favicon.svg          # SVG favicon (purple "L" logo)
+│   ├── images/
+│   │   ├── og-image.svg     # OG image source (SVG)
+│   │   └── og-image.png     # OG image (rasterized PNG for social cards)
+│   └── visualization.html   # Interactive cognitive architecture visualization (SVG + JS particles)
+├── getting-started/
+│   ├── index.md             # Getting Started hub (audience routing table)
+│   ├── quickstart-agent.md  # Cognitive Agent Quickstart (tick cycle, dreaming, 15 min)
+│   ├── quickstart-ruby.md   # Extension Dev Quickstart (scaffold LEX gem, 10 min)
+│   └── quickstart-llm.md   # LLM Routing Quickstart (multi-provider, Tier 0 cache, 10 min)
+├── index.md                 # Home page (hero section with embedded visualization, install, quick links)
+├── architecture.md          # Architecture deep-dive (system diagram, tick/dream cycles, cognitive domains)
+├── philosophy.md            # Project philosophy and design principles
+├── extensions.md            # Extension catalog (all 73 LEXs across 6 categories)
+├── compatibility.md         # Ruby version and infrastructure compatibility matrix
+├── enterprise.md            # Enterprise features (security, Vault, RBAC, deployment)
+├── settings.md              # Comprehensive settings reference (all subsystems, every config key)
+├── .github/
+│   ├── workflows/
+│   │   └── pages.yml        # GitHub Pages deployment (builds Jekyll, deploys to pages)
+│   ├── CODEOWNERS           # Code ownership (@Esity for all files)
+│   └── dependabot.yml       # Weekly updates for github-actions and bundler
+├── CNAME                    # GitHub Pages custom domain: legionio.dev
+├── Gemfile                  # Jekyll ~> 4.3, just-the-docs ~> 0.10, jekyll-seo-tag ~> 2.8
+├── Gemfile.lock             # Dependency lock
+├── README.md                # Basic project readme with dev instructions
+└── .gitignore               # Ignores _site/, .sass-cache/, .jekyll-cache/, vendor/
 ```
 
 ## Key Pages
 
-| Page | Path | Audience |
-|------|------|----------|
-| Home | `index.md` | All visitors |
-| Architecture | `architecture.md` | Developers |
-| Getting Started | `getting-started/` | New users |
-| Extensions | `extensions.md` | Extension authors |
-| Philosophy | `philosophy.md` | All visitors |
-| Compatibility | `compatibility.md` | Integrators |
-| Enterprise | `enterprise.md` | Enterprise users |
+| Page | Path | nav_order | Audience |
+|------|------|-----------|----------|
+| Home | `index.md` | 1 | All visitors |
+| Philosophy | `philosophy.md` | 2 | All visitors |
+| Architecture | `architecture.md` | 3 | Developers |
+| Enterprise | `enterprise.md` | 4 | Enterprise users |
+| Settings Reference | `settings.md` | 4 | Operators, developers |
+| Extensions | `extensions.md` | 5 | Extension authors |
+| Compatibility | `compatibility.md` | 6 | Integrators |
+| Getting Started | `getting-started/` | 7 | New users |
 
 ## Development
 
@@ -51,10 +69,19 @@ bundle exec jekyll serve --livereload
 # Site available at http://localhost:4000
 ```
 
+## CI/CD
+
+- GitHub Pages deployment via `.github/workflows/pages.yml`
+- Triggers on push to `origin` branch or manual `workflow_dispatch`
+- Builds with Ruby 3.4, Jekyll in production mode
+- Dependabot watches github-actions and bundler weekly
+
 ## Design Notes
 
-- Theme: just-the-docs (https://just-the-docs.com/)
-- The hero section in `index.md` embeds `assets/visualization.html` — an interactive cognitive architecture visualization
+- Theme: just-the-docs (dark color scheme)
+- Plugins: jekyll-seo-tag
+- The hero section in `index.md` embeds `assets/visualization.html` — an animated SVG with rotating orbital rings and particle system (pure CSS animations + vanilla JS)
+- `_includes/head_custom.html` provides OG/Twitter meta tags and all hero CSS styling
 - Content on this site is user-facing marketing/docs, not AI-facing context. For AI-facing docs, see `/Users/miverso2/rubymine/legion/docs/`
 
 ---

--- a/architecture.md
+++ b/architecture.md
@@ -10,75 +10,86 @@ description: "Technical architecture overview of the LegionIO cognitive framewor
 
 ```
                           +--------------------------------------+
-                          |          LegionIO v1.4.108           |
+                          |          LegionIO v1.6.37            |
                           |    CLI  /  REST API  /  MCP  / Chat  |
                           +-----------------+--------------------+
                                             |
               +----------+----------+-------+--------+----------+----------+
               |          |          |       |        |          |          |
           transport    crypt      data   cache    settings    llm       gaia
-          (RabbitMQ)  (Vault)  (Sequel) (Redis)  (config)  (ruby_llm) (tick)
+          (RabbitMQ)  (Vault)  (Sequel) (Redis)  (config)  (pipeline) (tick)
               |          |          |       |        |          |          |
               +----------+----------+-------+--------+----------+----------+
                                             |
-                  +-------------------------+-------------------------+
-                  |                         |                         |
-           18 Core LEXs             13 Cognitive Domains       29 Service LEXs
-         (tasker, synapse,        (234 sub-modules:           (slack, redis, http,
-          scheduler, node,         memory, emotion,            ssh, s3, vault,
-          conditioner...)          trust, prediction...)       github, chef...)
+                      +---------------------+---------------------+
+                      |                     |                     |
+                   apollo              19-step LLM           extensions
+                (knowledge)             pipeline          (LEX ecosystem)
+                      |                     |                     |
+              +-------+-------+     +-------+-------+     +------+------+
+              |               |     |               |     |             |
+          local SQLite    global  governance    tool    18 Core    13 Cognitive
+          + FTS5        pgvector  (RBAC,PHI,   dispatch  LEXs      Domains
+                                  billing)    (MCP+LEX)            (234 modules)
 ```
 
 ## Core Libraries
 
 | Library | Version | Purpose |
 |:--------|:--------|:--------|
-| legion-transport | 1.2.6 | RabbitMQ AMQP messaging with clustering, TLS, spool buffer |
-| legion-crypt | 1.4.4 | Encryption, HashiCorp Vault, JWT, multi-cluster Vault |
-| legion-data | 1.4.8 | Database persistence (SQLite/PostgreSQL/MySQL via Sequel) |
-| legion-cache | 1.3.3 | Two-tier caching (Redis/Memcached with local fallback) |
-| legion-settings | 1.3.8 | Config management, schema validation, secret resolver, DNS bootstrap |
-| legion-llm | 0.3.11 | LLM integration with three-tier model escalation |
-| legion-gaia | 0.9.8 | Cognitive coordination (tick cycle, dream cycle, channels) |
-| legion-mcp | 0.4.0 | MCP server with Tier 0 behavioral intelligence routing |
-| legion-rbac | 0.2.3 | Role-based access control (Vault-style flat policies) |
-| legion-tty | 0.4.29 | Terminal UI (prompts, tables, spinners, AI chat shell) |
-| legion-logging | 1.2.5 | Console + structured JSON logging + SIEM export |
-| legion-json | 1.2.0 | JSON serialization (multi_json) |
+| legion-transport | 1.4.11 | RabbitMQ AMQP + optional Kafka, connection pools, spool buffer, tenant topology |
+| legion-crypt | 1.4.26 | Encryption, multi-cluster Vault, JWT, SPIFFE/SVID, Kerberos auto-auth, mTLS, cert rotation |
+| legion-data | 1.6.16 | Database persistence (SQLite/PostgreSQL/MySQL via Sequel), Extract, AuditRecord, archival |
+| legion-cache | 1.3.18 | Two-tier caching (Redis/Memcached with PHI-aware TTL caps, Memory adapter for lite mode) |
+| legion-settings | 1.3.24 | Config management, schema validation, secret resolver, DNS bootstrap, absorber defaults |
+| legion-llm | 0.5.20 | 19-step LLM pipeline with RBAC, classification, RAG, billing, metering, confidence scoring |
+| legion-gaia | 0.9.29 | Cognitive coordination (24-phase tick/dream cycle, channels, router, workflow DSL, proactive messaging) |
+| legion-mcp | 0.6.6 | MCP server with 60 tools, Tier 0 behavioral intelligence, pattern learning, self-generating functions |
+| legion-apollo | 0.3.5 | Shared knowledge store (local SQLite+FTS5, global pgvector, entity-relationship graph) |
+| legion-rbac | 0.2.8 | Role-based access control (Vault-style flat policies, Kerberos/Entra claims mapping) |
+| legion-tty | 0.4.40 | Terminal UI (115+ slash commands, daemon-routed chat, raw-mode rendering, onboarding wizard) |
+| legion-logging | 1.4.2 | Structured JSON logging, async writer, SIEM export, PII/PHI redaction, event categories |
+| legion-json | 1.3.1 | JSON serialization (parse, generate, pretty, fast) |
 
 ## The Tick Cycle
 
-Every agent runs a 13-phase cognitive loop every tick:
+Every agent runs a 16-phase cognitive loop every tick:
 
 | Phase | Name | What Happens |
 |:------|:-----|:-------------|
 | 1 | Sensory Processing | Perceive environment, ingest new inputs |
 | 2 | Emotional Evaluation | Evaluate inputs against emotional state |
 | 3 | Memory Retrieval | Search episodic and semantic memory for relevant context |
-| 4 | Knowledge Retrieval | Query Apollo shared knowledge store |
+| 4 | Knowledge Retrieval | Query Apollo shared knowledge store (local + global) |
 | 5 | Identity Entropy Check | Verify agent identity coherence |
 | 6 | Working Memory Integration | Combine inputs, memories, knowledge into working state |
 | 7 | Procedural Check | Check for matching procedural patterns (habits) |
 | 8 | Prediction Engine | Generate predictions, compare with reality |
 | 9 | Mesh Interface | Coordinate with other agents in the mesh |
-| 10 | Gut Instinct | Fast heuristic evaluation (somatic markers) |
-| 11 | Action Selection | Choose action based on all preceding phases |
-| 12 | Memory Consolidation | Store new experiences in memory |
-| 13 | Post-Tick Reflection | Metacognitive review of the tick |
+| 10 | Social Cognition | Update social models of other agents and users |
+| 11 | Theory of Mind | Model other agents' beliefs and intentions |
+| 12 | Gut Instinct | Fast heuristic evaluation (somatic markers) |
+| 13 | Action Selection | Choose action based on all preceding phases |
+| 14 | Memory Consolidation | Store new experiences in memory |
+| 15 | Homeostasis Regulation | Balance energy, rhythm, and fatigue recovery |
+| 16 | Post-Tick Reflection | Metacognitive review of the tick |
 
 ## The Dream Cycle
 
-When an agent goes idle, it enters a 7-phase dream cycle:
+When an agent goes idle, it enters an 8-phase dream cycle:
 
 | Phase | Name | What Happens |
 |:------|:-----|:-------------|
 | 1 | Memory Audit | Review recent memories for importance |
 | 2 | Association Walk | Find connections between unrelated memories |
 | 3 | Contradiction Resolution | Resolve conflicting beliefs or memories |
-| 4 | Agenda Formation | Form new priorities based on consolidated knowledge |
-| 5 | Consolidation Commit | Persist reorganized memories |
-| 6 | Dream Reflection | Evaluate what the dream cycle produced |
-| 7 | Dream Narration | Generate a natural-language dream journal |
+| 4 | Identity Entropy | Verify identity coherence during dream state |
+| 5 | Agenda Formation | Form new priorities based on consolidated knowledge |
+| 6 | Consolidation Commit | Persist reorganized memories |
+| 7 | Knowledge Promotion | Promote dream insights to Apollo shared knowledge |
+| 8 | Dream Reflection | Evaluate what the dream cycle produced |
+
+Note: Dream Narration (the old phase 7) has been replaced by Knowledge Promotion. Dream insights now write directly to the Apollo shared knowledge store rather than producing a natural-language journal.
 
 ## Cognitive Domains
 
@@ -107,6 +118,8 @@ Extensions are Ruby gems named `lex-*`, auto-discovered at boot via `Bundler.loa
 Each extension defines:
 - **Runners** — callable functions (business logic)
 - **Actors** — execution modes (subscription, polling, interval, one-shot, loop)
+- **Absorbers** — pattern-matched content acquisition (URLs, files, meetings)
+- **Hooks** — lifecycle interceptors (auth, routing, transformation)
 - **Transport** — AMQP exchanges, queues, routing keys
 - **Helpers** — shared utilities, client connections
 
@@ -126,10 +139,10 @@ Deterministic startup order:
 
 ```
 Logging -> Settings -> Crypt -> Transport -> Cache -> Data
-   -> RBAC -> LLM -> GAIA -> Telemetry -> Extensions -> API
+   -> RBAC -> LLM -> Apollo -> GAIA -> Telemetry -> Extensions -> API
 ```
 
-GAIA boots before extensions so the tick cycle and channel abstraction are ready when cognitive extensions wire their phase handlers.
+Apollo boots between LLM and GAIA so the knowledge store is available for cognitive phase wiring.
 
 Two-phase extension loading: all extensions require + autobuild first, then `hook_all_actors` starts AMQP timers and subscriptions.
 
@@ -143,13 +156,13 @@ legion start
 legion task run http.request.get url:https://example.com
 legion dashboard
 
-# Interactive AI Chat
+# Interactive AI Chat (routed through daemon 19-step pipeline)
 legion chat
 
 # REST API (Sinatra + Puma)
 curl http://localhost:4567/api/v1/tasks
 
-# MCP Server (Model Context Protocol)
+# MCP Server (60 tools, Tier 0 behavioral routing)
 legion mcp
 ```
 
@@ -163,11 +176,47 @@ legion mcp
 
 Autonomy scales with confidence: **Observe** (0-0.3) -> **Filter** (0.3-0.6) -> **Transform** (0.6-0.8) -> **Autonomous** (0.8-1.0).
 
+Below the Autonomous threshold, Synapse emits proposals and routes them through an adversarial challenge pipeline before execution. Actions that pass challenge are logged with full trace; actions that fail are auto-reverted.
+
 ## Apollo: Shared Knowledge
 
-Durable knowledge store for the cognitive mesh. PostgreSQL + pgvector.
+Durable knowledge store for the cognitive mesh. Two tiers: node-local SQLite+FTS5 and global PostgreSQL+pgvector.
 
+- **Local store**: SQLite with FTS5 full-text search, content hash dedup, configurable TTL (5-year default), cosine rerank on embedded entries
+- **Global store**: PostgreSQL + pgvector for cross-agent semantic retrieval
+- **Entity-relationship graph**: Local SQLite-backed graph with BFS traversal, typed edges, and depth limiting
 - **Confidence decay**: Knowledge starts at 0.5, strengthened by corroboration, weakened by time
-- **Semantic retrieval**: Cosine similarity over 1536-dimensional embeddings
+- **Semantic retrieval**: Cosine similarity over 1024-dimensional embeddings
 - **Cross-agent sharing**: Agents interact via RabbitMQ only — no direct DB access
 - **Knowledge lifecycle**: candidate -> confirmed -> decayed -> archived
+- **Self-knowledge**: Ships with 10 built-in documents about its own architecture, auto-ingested on boot
+
+## LLM Pipeline
+
+Every LLM call routes through a 19-step governance pipeline. Steps are profile-aware — GAIA cognitive calls skip governance, external calls get full enforcement.
+
+| Step | Name | What Happens |
+|:-----|:-----|:-------------|
+| 1 | Authentication | Verify caller identity |
+| 2 | RBAC | Enforce role-based access control |
+| 3 | Context Load | Load conversation history |
+| 4 | Intent Analysis | Classify request intent and complexity |
+| 5 | Router | Select provider/model/tier based on routing rules |
+| 6 | Classification | PII/PHI content scanning and classification |
+| 7 | GAIA Advisory | Pre-flight enrichment from cognitive layer |
+| 8 | RAG Context | Retrieve relevant knowledge from Apollo |
+| 9 | MCP Discovery | Discover available tools from MCP servers |
+| 10 | Billing | Budget enforcement and cost estimation |
+| 11 | Provider Call | Execute LLM inference |
+| 12 | Response Normalization | Normalize provider-specific response format |
+| 13 | Confidence Scoring | Score response quality (logprobs, heuristics, or caller-provided) |
+| 14 | Tool Calls | Dispatch tool calls to MCP or LEX runners |
+| 15 | Context Store | Persist conversation state |
+| 16 | RAG Guard | Post-generation faithfulness check |
+| 17 | Metering | Record token usage and cost |
+| 18 | Audit | Publish audit event with full trace |
+| 19 | Knowledge Capture | Write research synthesis back to Apollo |
+
+Three caller profiles control which steps run: **external** (all steps), **gaia** (skips governance), **system** (minimal — auth and provider only).
+
+[Full Pipeline Reference]({% link pipeline.md %})

--- a/architecture.md
+++ b/architecture.md
@@ -83,13 +83,11 @@ When an agent goes idle, it enters an 8-phase dream cycle:
 | 1 | Memory Audit | Review recent memories for importance |
 | 2 | Association Walk | Find connections between unrelated memories |
 | 3 | Contradiction Resolution | Resolve conflicting beliefs or memories |
-| 4 | Identity Entropy | Verify identity coherence during dream state |
-| 5 | Agenda Formation | Form new priorities based on consolidated knowledge |
-| 6 | Consolidation Commit | Persist reorganized memories |
-| 7 | Knowledge Promotion | Promote dream insights to Apollo shared knowledge |
-| 8 | Dream Reflection | Evaluate what the dream cycle produced |
-
-Note: Dream Narration (the old phase 7) has been replaced by Knowledge Promotion. Dream insights now write directly to the Apollo shared knowledge store rather than producing a natural-language journal.
+| 4 | Agenda Formation | Form new priorities based on consolidated knowledge |
+| 5 | Consolidation Commit | Persist reorganized memories |
+| 6 | Knowledge Promotion | Promote dream insights to Apollo shared knowledge |
+| 7 | Dream Reflection | Evaluate what the dream cycle produced |
+| 8 | Dream Narration | Generate natural-language narrative of the dream cycle |
 
 ## Cognitive Domains
 

--- a/compatibility.md
+++ b/compatibility.md
@@ -29,10 +29,10 @@ description: "Tested versions and compatibility matrix for LegionIO."
 
 | Provider | Extension | Models Tested |
 |:---------|:----------|:-------------|
-| Anthropic | lex-claude | Claude Opus 4, Sonnet 4, Haiku 3.5 |
+| Anthropic | lex-claude | Claude Opus 4.6, Sonnet 4.6, Haiku 4.5 |
 | AWS Bedrock | lex-bedrock | Claude, Llama, Mistral via Bedrock |
-| OpenAI | lex-openai | GPT-4o, GPT-4-turbo, o1, o3 |
-| Google | lex-gemini | Gemini 2.5 Pro, Flash |
+| OpenAI | lex-openai | GPT-4.1, GPT-4o, o3, o4-mini |
+| Google | lex-gemini | Gemini 2.5 Pro, 2.5 Flash |
 | Azure AI | lex-azure-ai | Azure-hosted models via Foundry |
 | xAI | lex-xai | Grok models |
 | Local (Ollama) | legion-llm | Any Ollama-served model |
@@ -54,6 +54,7 @@ brew tap LegionIO/tap
 brew install legionio-ruby  # Ruby + YJIT + native gems
 brew install legionio       # Daemon + pure-Ruby gems
 brew install legion-tty     # Terminal UI gems
+brew install legion-dev     # Development tools
 ```
 
-Three-formula split: `legionio-ruby` (Ruby runtime), `legionio` (daemon), `legion-tty` (terminal tools).
+Four-formula split: `legionio-ruby` (Ruby runtime), `legionio` (daemon), `legion-tty` (terminal tools), `legion-dev` (development).

--- a/enterprise.md
+++ b/enterprise.md
@@ -49,7 +49,7 @@ Built-in compliance profiles for regulated environments:
 - **PII**: Personally identifiable information detection in LLM pipeline (SSN, email, phone, MRN, DOB patterns)
 - **FedRAMP**: Federal risk authorization profile
 
-All four compliance types are enabled by default at `confidential` classification level. Compliance profile is injected into the LLM pipeline Classification step (step 6) automatically.
+All four compliance types are enabled by default with a `confidential` classification level. When active, the compliance profile is injected into the LLM pipeline Classification step (step 6) automatically. Disable individual types via `compliance.phi_enabled`, `compliance.pci_enabled`, etc.
 
 ## Access Control (legion-rbac)
 

--- a/enterprise.md
+++ b/enterprise.md
@@ -1,6 +1,6 @@
 ---
 title: Enterprise
-nav_order: 4
+nav_order: 8
 description: "Enterprise capabilities: security, compliance, audit, and operational maturity."
 ---
 
@@ -40,6 +40,17 @@ LegionIO is built by someone who does infrastructure for a living. Security, aud
 - Database operations use parameterized queries via Sequel ORM
 - File permission system with deny list (~/.ssh, ~/.gnupg, ~/.aws/credentials)
 
+### Compliance Framework (LegionIO)
+
+Built-in compliance profiles for regulated environments:
+
+- **PHI**: Protected health information — PHI-aware cache TTL caps (3600s max), PHI tagging (`Compliance::PhiTag`), access logging (`Compliance::PhiAccessLog`), cryptographic erasure (`Compliance::PhiErasure`)
+- **PCI**: Payment card industry data classification
+- **PII**: Personally identifiable information detection in LLM pipeline (SSN, email, phone, MRN, DOB patterns)
+- **FedRAMP**: Federal risk authorization profile
+
+All four compliance types are enabled by default at `confidential` classification level. Compliance profile is injected into the LLM pipeline Classification step (step 6) automatically.
+
 ## Access Control (legion-rbac)
 
 Vault-style flat policies for fine-grained access control:
@@ -62,6 +73,29 @@ Vault-style flat policies for fine-grained access control:
 - Extension lifecycle tracking via catalog state machine
 - Health checks and node status reporting
 - Distributed scheduling with leader election
+
+### LLM Governance Pipeline
+
+Every LLM call runs through a [19-step governance pipeline]({% link pipeline.md %}):
+
+- RBAC enforcement on every call
+- PII/PHI classification before data leaves the network
+- Budget enforcement with per-session spending caps
+- Full audit trail with distributed tracing
+- Knowledge capture writes synthesis back to Apollo
+- Confidence scoring on every response
+
+The pipeline is enabled by default. Individual steps degrade gracefully when their backing subsystems are not loaded.
+
+### Tamper-Evident Audit
+
+`Legion::Data::AuditRecord` provides SHA-256 hash chain verification for audit records:
+
+- Append-only records linked by `parent_hash` and `chain_hash`
+- Chain verification walks and re-derives every hash
+- PostgreSQL enforces immutability with `NO UPDATE/DELETE` rules
+- Tiered retention: hot (database) -> warm (archive) -> cold (compressed JSONL to S3/local)
+- `legion audit verify_chain` CLI command for integrity checks
 
 ## Deployment
 
@@ -95,6 +129,14 @@ Everything is a JSON config file. Config resolution order:
 5. DNS bootstrap (`legion-bootstrap.<domain>` TXT records)
 
 Secret resolution happens after Vault is available: `vault://secret/path#key` URIs are resolved automatically.
+
+### Resilience
+
+- **Transport spool**: JSONL disk buffer when RabbitMQ is unavailable (72hr retention, encrypted at rest, 500MB total limit)
+- **Connection pools**: RabbitMQ session pooling with automatic failover across cluster nodes
+- **Force reconnect**: Detects pathological Bunny recovery loops and performs full session replacement
+- **Network watchdog**: Background task monitors connectivity, pauses actors on sustained failure, triggers reload on recovery (opt-in via `network.watchdog.enabled`)
+- **Dynamic Vault leases**: `LeaseManager` handles credential rotation transparently via `lease://` URI scheme
 
 ## Scale Characteristics
 

--- a/extensions.md
+++ b/extensions.md
@@ -45,6 +45,7 @@ Framework plumbing — task management, scheduling, health monitoring, internal 
 | lex-eval | Model evaluation and benchmarking |
 | lex-workflow | Multi-step workflow definitions |
 | lex-llm-gateway | LLM request routing and load balancing |
+| lex-react | Reactive event processing and signal evaluation |
 
 ## Cognitive Architecture
 
@@ -69,6 +70,9 @@ Framework plumbing — task management, scheduling, health monitoring, internal 
 | lex-dream | Dream cycle orchestration and journal generation |
 | lex-mind-growth | Cognitive development — proposer, analyzer, builder, validator |
 | lex-reflect | Self-reflection and introspection engine |
+| lex-knowledge | Document knowledge base with corpus monitoring and RAG |
+| lex-extinction | Agent lifecycle termination governance |
+| lex-cortex | Legacy cognitive coordinator (absorbed into legion-gaia) |
 
 ## GAIA-Tier Extensions
 
@@ -80,6 +84,14 @@ Higher-order coordination and cognitive infrastructure.
 | lex-gaia-channel | Channel abstraction for perception-to-action routing |
 | lex-gaia-router | Message routing within the cognitive mesh |
 | lex-gaia-dream | Dream cycle coordination |
+| lex-privatecore | Privacy enforcement for the cognitive stack |
+| lex-tick | Tick cycle orchestrator (required by GAIA) |
+
+## Mesh Networking
+
+| Extension | Description |
+|:----------|:-----------|
+| lex-mesh | Inter-agent mesh networking — peer discovery, RPC, broadcast, multicast |
 
 ## LLM Provider Integrations
 
@@ -163,3 +175,20 @@ legion generate actor poller
 ```
 
 See the [Extension Dev Quickstart]({% link getting-started/quickstart-ruby.md %}) for a full walkthrough.
+
+## Absorbers
+
+Absorbers are a new extension component type for pattern-matched content acquisition. An absorber watches for URLs, files, or meeting transcripts that match its patterns, extracts content, and ingests it into the Apollo knowledge store.
+
+```bash
+# Scaffold an absorber
+legion generate absorber my_absorber
+
+# Absorb a URL
+legion absorb url https://example.com/doc
+
+# List registered absorbers
+legion absorb list
+```
+
+See the [Architecture Overview]({% link architecture.md %}) for how absorbers fit into the extension system.

--- a/extensions.md
+++ b/extensions.md
@@ -66,7 +66,7 @@ Framework plumbing — task management, scheduling, health monitoring, internal 
 | lex-agentic-homeostasis | Balance, rhythm, energy, fatigue recovery |
 | lex-agentic-defense | Bias detection, error monitoring, cognitive immune system |
 | lex-agentic-integration | Cross-modal binding, coherence, Global Workspace Theory |
-| lex-apollo | Shared knowledge store (PostgreSQL + pgvector) |
+| lex-apollo | Two-tier shared knowledge store (local SQLite+FTS5 + global PostgreSQL+pgvector) |
 | lex-dream | Dream cycle orchestration and journal generation |
 | lex-mind-growth | Cognitive development — proposer, analyzer, builder, validator |
 | lex-reflect | Self-reflection and introspection engine |

--- a/getting-started/quickstart-agent.md
+++ b/getting-started/quickstart-agent.md
@@ -8,7 +8,7 @@ description: "See the cognitive tick cycle in action — an agent that perceives
 # Cognitive Agent Quickstart
 
 **Time:** 15 minutes
-**You'll see:** An agent running the 13-phase tick cycle, having a conversation with memory and mood, then dreaming during idle time.
+**You'll see:** An agent running the 16-phase tick cycle, having a conversation with memory and mood, then dreaming during idle time.
 **Prerequisites:** Ruby >= 3.4, RabbitMQ running
 
 {: .note }
@@ -38,14 +38,14 @@ $ legionio start
   Legion::Settings Loaded
   Legion::Rbac loaded
   Legion::LLM loaded (provider: anthropic, model: claude-sonnet-4-6)
-  Legion::Gaia loaded (tick cycle: 13 phases, dream cycle: 7 phases)
+  Legion::Gaia loaded (tick cycle: 16 phases active, 8 dream phases standby)
   Logging hooks registered for RMQ publishing
   73 extensions loaded with subscription:42,every:18,poll:8,once:3,loop:2
   Starting Legion API on 0.0.0.0:4567
-  Started Legion v1.4.107
+  Started Legion v1.6.37
 ```
 
-The key lines to notice: GAIA comes up with 13 tick phases and 7 dream phases before any extensions load. The cognitive layer is the foundation, not a plugin.
+The key lines to notice: GAIA comes up with 16 tick phases and 8 dream phases before any extensions load. The cognitive layer is the foundation, not a plugin.
 
 ## Step 3: Chat with a Cognitive Agent
 
@@ -102,7 +102,7 @@ you > check if the API is up
 
 [tool] http.get(url: "http://0.0.0.0:4567/status")
 
-legion > The API is responding. Status 200, version 1.4.107, uptime 4m 12s.
+legion > The API is responding. Status 200, version 1.6.37, uptime 4m 12s.
 ```
 
 ## Step 4: Watch It Dream
@@ -171,7 +171,7 @@ It went idle with a loose end and woke up with it prioritized. That's not retrie
 
 ## What Just Happened?
 
-Every tick, the agent ran 13 cognitive phases — not just "call LLM, return response." It perceived your input, evaluated it emotionally, retrieved relevant memories, checked predictions, selected an action, and reflected on the interaction.
+Every tick, the agent ran 16 cognitive phases — not just "call LLM, return response." It perceived your input, evaluated it emotionally, retrieved relevant memories, checked predictions, selected an action, and reflected on the interaction.
 
 When it went idle, it dreamed — consolidating memories, resolving contradictions, forming new priorities. Not because you told it to. Because that's what brains do.
 

--- a/getting-started/quickstart-llm.md
+++ b/getting-started/quickstart-llm.md
@@ -37,9 +37,9 @@ Verify the install:
 
 ```
 $ legion version
-LegionIO v1.4.107
-legion-llm  v0.3.11
-legion-mcp  v0.4.0
+LegionIO v1.6.37
+legion-llm  v0.5.20
+legion-mcp  v0.6.6
 ```
 
 ---
@@ -71,7 +71,7 @@ Export your key and start a chat session:
 $ export ANTHROPIC_API_KEY=sk-ant-...
 
 $ legion chat
-LegionIO v1.4.107  |  provider: anthropic  |  model: claude-3-5-haiku-20241022  |  tier: cloud
+LegionIO v1.6.37  |  provider: anthropic  |  model: claude-3-5-haiku-20241022  |  tier: cloud
 Type 'exit' to quit.
 
 you > What are the primary benefits of async job queues?
@@ -139,7 +139,7 @@ Start chat again. The startup line now reflects the active routing strategy.
 
 ```
 $ legion chat
-LegionIO v1.4.107  |  routing: cost_optimized  |  providers: ollama, anthropic, openai
+LegionIO v1.6.37  |  routing: cost_optimized  |  providers: ollama, anthropic, openai
 Type 'exit' to quit.
 
 you > What day comes after Tuesday?
@@ -175,7 +175,7 @@ Notice that the simple factual question was routed to the local Ollama model (fa
 
 ```
 $ legion chat
-LegionIO v1.4.107  |  routing: cost_optimized  |  providers: ollama (unavailable), anthropic, openai
+LegionIO v1.6.37  |  routing: cost_optimized  |  providers: ollama (unavailable), anthropic, openai
 WARNING: ollama unreachable at http://localhost:11434 — removed from pool
 Type 'exit' to quit.
 
@@ -199,7 +199,7 @@ Ask the same question twice to see it in action:
 
 ```
 $ legion chat
-LegionIO v1.4.107  |  routing: cost_optimized  |  providers: ollama, anthropic, openai
+LegionIO v1.6.37  |  routing: cost_optimized  |  providers: ollama, anthropic, openai
 Type 'exit' to quit.
 
 you > List the three OSI layers most relevant to load balancer configuration.

--- a/getting-started/quickstart-llm.md
+++ b/getting-started/quickstart-llm.md
@@ -56,8 +56,13 @@ mkdir -p ~/.legionio/settings
 cat > ~/.legionio/settings/llm.json << 'EOF'
 {
   "llm": {
-    "provider": "anthropic",
-    "api_key": "env://ANTHROPIC_API_KEY"
+    "default_provider": "anthropic",
+    "providers": {
+      "anthropic": {
+        "enabled": true,
+        "api_key": "env://ANTHROPIC_API_KEY"
+      }
+    }
   }
 }
 EOF
@@ -101,21 +106,28 @@ Update `llm.json` to declare multiple providers. LegionIO will route across them
 cat > ~/.legionio/settings/llm.json << 'EOF'
 {
   "llm": {
+    "default_provider": "anthropic",
     "providers": {
       "anthropic": {
-        "api_key": "env://ANTHROPIC_API_KEY",
-        "tier": "cloud"
+        "enabled": true,
+        "api_key": "env://ANTHROPIC_API_KEY"
       },
       "openai": {
-        "api_key": "env://OPENAI_API_KEY",
-        "tier": "cloud"
+        "enabled": true,
+        "api_key": "env://OPENAI_API_KEY"
       },
       "ollama": {
-        "base_url": "http://localhost:11434",
-        "tier": "local"
+        "enabled": true,
+        "base_url": "http://localhost:11434"
       }
     },
-    "routing": "cost_optimized"
+    "routing": {
+      "enabled": true,
+      "tiers": {
+        "local": { "provider": "ollama" },
+        "cloud": { "providers": ["anthropic", "openai"] }
+      }
+    }
   }
 }
 EOF

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ description: "Cognitive architecture for AI agents. Not a prompt wrapper."
   <div class="hero-overlay">
     <h1>LegionIO</h1>
     <p class="hero-tagline">What if your AI agent had a brain &mdash; not just a prompt?</p>
-    <p class="hero-stats">73 extension gems &middot; 234 cognitive modules &middot; 23,000+ specs</p>
+    <p class="hero-stats">73 extension gems &middot; 60 MCP tools &middot; 24-phase cognitive cycle &middot; 23,000+ specs</p>
     <div class="hero-install">
       <span class="hero-prompt">$ </span>gem install legionio
     </div>
@@ -41,7 +41,7 @@ Pick your path — each one gets you to an "aha" moment in 15 minutes or less.
 
 ## The Cognitive Stack
 
-Every LegionIO agent runs a **tick cycle** — a 13-phase cognitive loop modeled on biological neural processing. Each tick, the agent perceives, remembers, predicts, decides, acts, and reflects. During idle periods, a 7-phase **dream cycle** consolidates and reorganizes memory.
+Every LegionIO agent runs a **tick cycle** — a 24-phase cognitive loop modeled on biological neural processing. 16 active phases run each tick: the agent perceives, remembers, predicts, decides, acts, and reflects. During idle periods, an 8-phase **dream cycle** consolidates memory, resolves contradictions, and forms new agendas.
 
 ```mermaid
 flowchart LR
@@ -55,19 +55,24 @@ flowchart LR
         F --> G["Procedural\nCheck"]
         G --> H["Prediction\nEngine"]
         H --> I["Mesh\nInterface"]
-        I --> J["Gut\nInstinct"]
+        I --> N["Social\nCognition"]
+        N --> O["Theory of\nMind"]
+        O --> J["Gut\nInstinct"]
         J --> K["Action\nSelection"]
         K --> L["Memory\nConsolidation"]
-        L --> M["Post-Tick\nReflection"]
+        L --> P["Homeostasis\nRegulation"]
+        P --> M["Post-Tick\nReflection"]
     end
 
     subgraph DREAM["Dream Cycle"]
         direction LR
         D1["Memory\nAudit"] --> D2["Association\nWalk"]
         D2 --> D3["Contradiction\nResolution"]
-        D3 --> D4["Agenda\nFormation"]
+        D3 --> D8["Identity\nEntropy"]
+        D8 --> D4["Agenda\nFormation"]
         D4 --> D5["Consolidation\nCommit"]
-        D5 --> D6["Dream\nReflection"]
+        D5 --> D9["Knowledge\nPromotion"]
+        D9 --> D6["Dream\nReflection"]
         D6 --> D7["Dream\nNarration"]
     end
 ```
@@ -78,14 +83,22 @@ flowchart LR
 
 ---
 
+## The LLM Pipeline
+
+Every LLM call runs through a **19-step governance pipeline** — not just "call the model." RBAC enforcement, PII/PHI classification, RAG context injection, budget guards, tool dispatch, knowledge capture, confidence scoring, and full audit trail. Every step is optional, composable, and independently removable.
+
+[Pipeline Deep-Dive]({% link pipeline.md %})
+
+---
+
 ## See It in Action
 
 <!-- TODO: Replace with asciinema embed or gif after recording (Task 2 from catalyst plan) -->
 
 ```
 $ legion start
-  Loading 73 extensions... done
-  Tick cycle: 13 phases active
+  73 extensions loaded
+  Tick cycle: 16 phases active, 8 dream phases standby
   Dream cycle: standby
   API: http://localhost:4567
   Ready.
@@ -126,6 +139,9 @@ legion start
 
 # Or just chat
 legion chat
+
+# Or start the 19-step LLM pipeline
+legion start
 ```
 
 **Requirements:** Ruby >= 3.4, RabbitMQ. Optional: PostgreSQL/MySQL/SQLite, Redis/Memcached, HashiCorp Vault.

--- a/index.md
+++ b/index.md
@@ -68,8 +68,7 @@ flowchart LR
         direction LR
         D1["Memory\nAudit"] --> D2["Association\nWalk"]
         D2 --> D3["Contradiction\nResolution"]
-        D3 --> D8["Identity\nEntropy"]
-        D8 --> D4["Agenda\nFormation"]
+        D3 --> D4["Agenda\nFormation"]
         D4 --> D5["Consolidation\nCommit"]
         D5 --> D9["Knowledge\nPromotion"]
         D9 --> D6["Dream\nReflection"]
@@ -140,8 +139,6 @@ legion start
 # Or just chat
 legion chat
 
-# Or start the 19-step LLM pipeline
-legion start
 ```
 
 **Requirements:** Ruby >= 3.4, RabbitMQ. Optional: PostgreSQL/MySQL/SQLite, Redis/Memcached, HashiCorp Vault.

--- a/philosophy.md
+++ b/philosophy.md
@@ -8,7 +8,7 @@ description: "Design principles and architecture philosophy for the LegionIO cog
 
 ## What LegionIO Is
 
-LegionIO is a cognitive architecture for AI agents built in Ruby. Agents run a 13-phase tick cycle modeled on biological neural processing — perceiving, remembering, predicting, deciding, acting, and reflecting every tick. When idle, they enter a 7-phase dream cycle that consolidates memory, resolves contradictions, and forms new agendas.
+LegionIO is a cognitive architecture for AI agents built in Ruby. Agents run a 16-phase tick cycle modeled on biological neural processing — perceiving, remembering, predicting, deciding, acting, and reflecting every tick. When idle, they enter an 8-phase dream cycle that consolidates memory, resolves contradictions, promotes knowledge, and forms new agendas.
 
 234 cognitive modules organized into 13 domain gems model distinct aspects of cognition: memory that fades, emotions that shift decisions, trust that's earned through interaction, predictions that fail and adapt. Every module is optional. They compose, interact, and adapt when others are absent.
 
@@ -32,7 +32,7 @@ An agent should have its own internal state, its own memory, its own judgment. I
 
 ### The tick cycle is the execution model
 
-Every agent runs the same 13-phase tick cycle: sensory processing, emotional evaluation, memory retrieval, knowledge retrieval, identity entropy check, working memory integration, procedural check, prediction engine, mesh interface, gut instinct, action selection, memory consolidation, post-tick reflection.
+Every agent runs the same 16-phase tick cycle: sensory processing, emotional evaluation, memory retrieval, knowledge retrieval, identity entropy check, working memory integration, procedural check, prediction engine, mesh interface, social cognition, theory of mind, gut instinct, action selection, memory consolidation, homeostasis regulation, post-tick reflection.
 
 This isn't decorative. Each phase does real computational work. Skipping phases changes behavior. The tick cycle is what makes a LegionIO agent an agent rather than a function that calls an LLM.
 

--- a/pipeline.md
+++ b/pipeline.md
@@ -185,9 +185,23 @@ The pipeline is configured via `~/.legionio/settings/llm.json`:
     "pipeline_enabled": true,
     "routing": {
       "enabled": true,
-      "tiers": ["cost_optimized"],
+      "tiers": {
+        "local": {
+          "provider": "ollama"
+        },
+        "fleet": {
+          "queue": "llm.inference"
+        },
+        "cloud": {
+          "providers": ["bedrock", "anthropic"]
+        }
+      },
       "health": {
-        "probe_interval_seconds": 30
+        "window_seconds": 300,
+        "circuit_breaker": {
+          "failure_threshold": 3,
+          "cooldown_seconds": 60
+        }
       }
     },
     "rag": {

--- a/pipeline.md
+++ b/pipeline.md
@@ -1,0 +1,251 @@
+---
+title: LLM Pipeline
+nav_order: 4
+description: "19-step governance pipeline for every LLM call. RBAC, classification, RAG, billing, audit, and knowledge capture — composable and profile-aware."
+---
+
+# The LLM Pipeline
+
+Most agent frameworks call the model and hope for the best. LegionIO runs every LLM call through a 19-step pipeline that enforces access control, classifies sensitive data, injects relevant knowledge, guards budgets, dispatches tools, scores confidence, and captures what was learned — before the response reaches the caller.
+
+The pipeline is enabled by default. Every `Legion::LLM.chat(message:)` call routes through it.
+
+---
+
+## Why a Pipeline?
+
+When you call an LLM in production, you need more than inference. You need:
+
+- **Who is calling?** RBAC enforcement based on caller identity.
+- **What are they sending?** PII/PHI classification before the data leaves your network.
+- **What does the agent already know?** RAG context from the Apollo knowledge store.
+- **Can they afford it?** Budget enforcement and cost estimation before the call.
+- **Was the response faithful?** Post-generation RAG guard checks.
+- **What did we learn?** Knowledge capture writes synthesis back to Apollo.
+- **What happened?** Full audit trail with distributed tracing.
+
+Most frameworks make you build this yourself. LegionIO ships it.
+
+---
+
+## The 19 Steps
+
+```mermaid
+flowchart TD
+    subgraph PRE["Pre-Provider"]
+        S1["1. Authentication"] --> S2["2. RBAC"]
+        S2 --> S3["3. Context Load"]
+        S3 --> S4["4. Intent Analysis"]
+        S4 --> S5["5. Router"]
+        S5 --> S6["6. Classification"]
+        S6 --> S7["7. GAIA Advisory"]
+        S7 --> S8["8. RAG Context"]
+        S8 --> S9["9. MCP Discovery"]
+        S9 --> S10["10. Billing"]
+    end
+
+    subgraph PROVIDER["Provider"]
+        S10 --> S11["11. Provider Call"]
+    end
+
+    subgraph POST["Post-Provider"]
+        S11 --> S12["12. Response Normalization"]
+        S12 --> S13["13. Confidence Scoring"]
+        S13 --> S14["14. Tool Calls"]
+        S14 --> S15["15. Context Store"]
+        S15 --> S16["16. RAG Guard"]
+        S16 --> S17["17. Metering"]
+        S17 --> S18["18. Audit"]
+        S18 --> S19["19. Knowledge Capture"]
+    end
+```
+
+### Step 1: Authentication
+
+Verify caller identity. Extracts principal from JWT, API key, or Kerberos ticket.
+
+### Step 2: RBAC
+
+Enforce role-based access control via `legion-rbac`. Checks caller permissions against the requested operation. Gracefully degrades when RBAC is not loaded — the pipeline never hard-fails on a missing optional component.
+
+### Step 3: Context Load
+
+Load conversation history from the `ConversationStore`. In-memory LRU hot layer (256 conversations) with optional database persistence via Sequel.
+
+### Step 4: Intent Analysis
+
+Classify request intent and complexity. Feeds into the router for tier selection.
+
+### Step 5: Router
+
+Select provider, model, and tier based on routing rules. The router evaluates rules in priority order with intent matching, schedule windows, cost multipliers, and health-aware circuit breakers.
+
+Three tiers:
+- **Local** — Ollama or on-device models (fast, free, air-gapped)
+- **Fleet** — shared inference servers via AMQP dispatch
+- **Cloud** — commercial APIs (Anthropic, OpenAI, Bedrock, Gemini, Azure AI, xAI)
+
+Escalation is automatic: if the selected model fails or produces low-quality output, the router walks up the `EscalationChain` to the next capable model.
+
+### Step 6: Classification
+
+Scan request content for PII and PHI patterns (SSN, email, phone, MRN, DOB). Classification levels only upgrade, never downgrade. Auto-enables when a compliance profile is active (`compliance.classification_level` is set).
+
+### Step 7: GAIA Advisory
+
+Pre-flight enrichment from the cognitive layer. When GAIA is running, the pipeline asks for relevant context from the current tick state — emotional valence, prediction state, working memory. This is what makes LegionIO responses contextually aware without prompt engineering.
+
+### Step 8: RAG Context
+
+Retrieve relevant knowledge from Apollo. Strategy selector chooses between full, hybrid, and compact RAG based on context window utilization:
+
+- **Low utilization** — full RAG (room for context)
+- **Medium utilization** — compact RAG (summarized chunks)
+- **High utilization** — skip RAG (preserve space for the response)
+
+Trivial queries (greetings, pings) skip RAG automatically. All thresholds are configurable.
+
+### Step 9: MCP Discovery
+
+Discover available tools from all healthy MCP servers via the `Legion::MCP::Client::Pool`. Aggregates tool lists across registered servers with TTL caching.
+
+### Step 10: Billing
+
+Budget enforcement via `CostEstimator`. Estimates request cost before the call. Rejects the request if the session budget would be exceeded. Budget is configurable per session (`llm.budget.session_usd`).
+
+### Step 11: Provider Call
+
+Execute LLM inference via the selected provider. Supports streaming — pre/post steps run normally, chunks are yielded to the caller. Multi-turn conversations inject prior messages via `session.add_message` before the final ask.
+
+### Step 12: Response Normalization
+
+Normalize provider-specific response format into a unified `Pipeline::Response` struct with content, tool calls, stop reason, model, and token counts.
+
+### Step 13: Confidence Scoring
+
+Score response quality using three sources in priority order:
+
+1. **Caller-provided** — explicit confidence score passed in the request
+2. **Model-native logprobs** — when the model returns token probabilities
+3. **Heuristic analysis** — refusal detection, truncation detection, repetition scoring, hedging language penalties, structured output bonus
+
+Scores map to bands: very_low (0-0.3), low (0.3-0.5), medium (0.5-0.7), high (0.7-0.9), very_high (0.9-1.0). Band boundaries are configurable.
+
+### Step 14: Tool Calls
+
+Dispatch non-builtin tool calls from the LLM response. The `ToolDispatcher` routes each call to the right handler:
+
+- **MCP client** — external tool servers
+- **LEX extension runner** — internal extension functions
+- **RubyLLM builtin** — framework-provided tools
+
+### Step 15: Context Store
+
+Persist conversation state back to the `ConversationStore` for future context loading.
+
+### Step 16: RAG Guard
+
+Post-generation faithfulness check against retrieved RAG context. Uses `lex-eval` evaluators (faithfulness, RAG relevancy) with a configurable threshold (default 0.7). Metadata is attached to the response without blocking.
+
+### Step 17: Metering
+
+Record token usage, provider, model, and status. Publishes metering events for cost tracking and chargeback. Auto-cost tracking records per-request cost via `CostTracker`.
+
+### Step 18: Audit
+
+Publish audit event to the `llm.audit` exchange with full distributed tracing (trace_id, span_id, exchange_id). The audit event includes the complete pipeline timeline with participant tracking.
+
+### Step 19: Knowledge Capture
+
+Write research synthesis back to Apollo. When the pipeline produces a substantive response to a knowledge query, the content is ingested into both local and global Apollo stores — tagged with the model and conversation context. Over time, the agent builds a knowledge base from its own work.
+
+---
+
+## Caller Profiles
+
+Not all LLM calls need full governance. The pipeline uses caller profiles to skip irrelevant steps:
+
+| Profile | Who | Steps Skipped |
+|:--------|:----|:-------------|
+| **external** | User-facing requests | None — full pipeline |
+| **gaia** | Cognitive layer (tick phases, dream cycle) | RBAC, classification, billing |
+| **system** | Internal framework calls | Most steps — auth and provider only |
+
+Profiles are derived from the `caller:` parameter. GAIA phases pass their identity automatically.
+
+---
+
+## Configuration
+
+The pipeline is configured via `~/.legionio/settings/llm.json`:
+
+```json
+{
+  "llm": {
+    "pipeline_enabled": true,
+    "routing": "cost_optimized",
+    "rag": {
+      "full_limit": 0.5,
+      "compact_limit": 0.75,
+      "min_confidence": 0.3
+    },
+    "confidence": {
+      "bands": {
+        "low": 0.3,
+        "medium": 0.5,
+        "high": 0.7,
+        "very_high": 0.9
+      }
+    },
+    "budget": {
+      "session_usd": 5.0
+    },
+    "cost_tracking": {
+      "auto": true
+    },
+    "metering": {
+      "auto": true
+    }
+  }
+}
+```
+
+Set `pipeline_enabled: false` to bypass the pipeline entirely and route directly to the provider. Individual steps degrade gracefully when their backing subsystems (RBAC, Apollo, GAIA) are not loaded.
+
+---
+
+## Streaming
+
+The pipeline supports streaming. Pre-provider steps run normally, then chunks are yielded to the caller as they arrive from the provider. Post-provider steps run after the stream completes.
+
+```ruby
+Legion::LLM.chat(message: "Explain event sourcing") do |chunk|
+  print chunk.content
+end
+```
+
+---
+
+## Error Handling
+
+The pipeline uses a typed error hierarchy with `retryable?` predicates:
+
+| Error | Retryable | Meaning |
+|:------|:----------|:--------|
+| `AuthError` | No | Authentication or RBAC failure |
+| `RateLimitError` | Yes | Provider rate limit (429) |
+| `ContextOverflow` | No | Input exceeds model context window |
+| `ProviderError` | Yes | Transient provider failure |
+| `ProviderDown` | Yes | Provider circuit breaker tripped |
+| `UnsupportedCapability` | No | Model lacks required capability |
+| `PipelineError` | No | Internal pipeline failure |
+
+Retryable errors trigger automatic escalation to the next model in the `EscalationChain`.
+
+---
+
+## What's Next
+
+- [Architecture Overview]({% link architecture.md %}) — understand the full system context
+- [Settings Reference]({% link settings.md %}) — every LLM pipeline configuration key
+- [Enterprise Overview]({% link enterprise.md %}) — compliance, audit, and cost recovery

--- a/pipeline.md
+++ b/pipeline.md
@@ -183,10 +183,16 @@ The pipeline is configured via `~/.legionio/settings/llm.json`:
 {
   "llm": {
     "pipeline_enabled": true,
-    "routing": "cost_optimized",
+    "routing": {
+      "enabled": true,
+      "tiers": ["cost_optimized"],
+      "health": {
+        "probe_interval_seconds": 30
+      }
+    },
     "rag": {
-      "full_limit": 0.5,
-      "compact_limit": 0.75,
+      "full_limit": 10,
+      "compact_limit": 5,
       "min_confidence": 0.3
     },
     "confidence": {

--- a/settings.md
+++ b/settings.md
@@ -302,7 +302,7 @@ File: `~/.legionio/settings/crypt.json`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | auto | Enable Vault integration (auto-detected from vault gem presence) |
+| `enabled` | boolean | `nil` | Enable Vault integration (when omitted/`nil`, auto-detected from Vault gem presence) |
 | `protocol` | string | `"http"` | Vault protocol (`http` or `https`) |
 | `address` | string | `"localhost"` | Vault server address |
 | `port` | integer | `8200` | Vault server port |
@@ -464,7 +464,7 @@ File: `~/.legionio/settings/llm.json`
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | Enable OpenAI provider |
 | `default_model` | string | `"gpt-4o"` | Default OpenAI model ID |
-| `api_key` | string | `["env://OPENAI_API_KEY", "env://CODEX_API_KEY"]` | OpenAI API key (fallback chain) |
+| `api_key` | string&nbsp;|&nbsp;array | `["env://OPENAI_API_KEY", "env://CODEX_API_KEY"]` | OpenAI API key (fallback chain) |
 
 ### llm.providers.gemini
 
@@ -554,7 +554,7 @@ Retrieval-Augmented Generation context injection from Apollo knowledge store.
 | `utilization_compact_threshold` | float | `0.7` | Context utilization ratio to switch to compact mode |
 | `utilization_skip_threshold` | float | `0.9` | Context utilization ratio to skip RAG entirely |
 | `trivial_max_chars` | integer | `20` | Messages shorter than this are checked against trivial patterns |
-| `trivial_patterns` | array | `["hello", "hi", "hey", "ping", ...]` | Patterns that skip RAG lookup |
+| `trivial_patterns` | array | `["hello", "hi", "hey", "ping"]` | Patterns that skip RAG lookup (example set; extend with other trivial greetings as needed) |
 
 ### llm.embedding
 
@@ -903,7 +903,7 @@ Channel adapters for human-agent communication.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `mode` | boolean | `false` | Enable cross-node message routing |
+| `enabled` | boolean | `false` | Enable cross-node message routing |
 | `allowed_worker_ids` | array | `[]` | Worker IDs permitted to route through GAIA |
 
 ### gaia.session

--- a/settings.md
+++ b/settings.md
@@ -189,7 +189,7 @@ Optional Kafka adapter for event streaming alongside RabbitMQ. Requires `rdkafka
 
 ### transport.spool
 
-Disk-based message buffer for when AMQP is unavailable. Spool is configured via method defaults, not the settings hash.
+Disk-based message buffer for when AMQP is unavailable. The defaults below live in code but can be overridden via `~/.legionio/settings/transport.json` under the `transport.spool` key.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -499,7 +499,7 @@ Dynamic model routing with tiered provider selection and health tracking.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | Enable dynamic routing |
-| `default_intent` | hash | `{privacy: "normal", capability: "moderate", cost: "normal"}` | Default request intent for routing decisions |
+| `default_intent` | hash | `{"privacy":"normal","capability":"moderate","cost":"normal"}` | Default request intent for routing decisions |
 | `rules` | array | `[]` | Custom routing rules |
 
 #### llm.routing.tiers

--- a/settings.md
+++ b/settings.md
@@ -39,14 +39,14 @@ File: `~/.legionio/settings/transport.json`
 | `user` | string | `"guest"` | Authentication username |
 | `password` | string | `"guest"` | Authentication password (supports `vault://` and `env://` URIs) |
 | `vhost` | string | `"/"` | RabbitMQ virtual host |
-| `read_timeout` | integer | `1` | Socket read timeout in seconds |
+| `read_timeout` | integer | `3` | Socket read timeout in seconds |
 | `heartbeat` | integer | `30` | AMQP heartbeat interval in seconds |
 | `automatically_recover` | boolean | `true` | Auto-reconnect on connection loss |
-| `continuation_timeout` | integer | `4000` | RPC continuation timeout in milliseconds |
-| `network_recovery_interval` | integer | `1` | Seconds between reconnection attempts |
-| `connection_timeout` | integer | `1` | TCP connection timeout in seconds |
+| `continuation_timeout` | integer | `8000` | RPC continuation timeout in milliseconds |
+| `network_recovery_interval` | integer | `2` | Seconds between reconnection attempts |
+| `connection_timeout` | integer | `10` | TCP connection timeout in seconds |
 | `frame_max` | integer | `65536` | Maximum AMQP frame size in bytes |
-| `recovery_attempts` | integer | `100` | Maximum reconnection attempts before giving up |
+| `recovery_attempts` | integer | `10` | Maximum reconnection attempts before giving up |
 | `logger_level` | string | `"info"` | Bunny client log level |
 
 ### transport.messages
@@ -74,6 +74,7 @@ File: `~/.legionio/settings/transport.json`
 |-----|------|---------|-------------|
 | `manual_ack` | boolean | `true` | Require explicit message acknowledgement |
 | `durable` | boolean | `true` | Survive broker restarts |
+| `exclusive` | boolean | `false` | Exclusive to the declaring connection |
 | `block` | boolean | `false` | Block on queue declare if it already exists |
 | `auto_delete` | boolean | `false` | Delete queue when last consumer disconnects |
 | `arguments` | hash | `{"x-queue-type": "quorum"}` | Queue arguments (quorum queues recommended) |
@@ -83,15 +84,120 @@ File: `~/.legionio/settings/transport.json`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `default_worker_pool_size` | integer | `1` | Default channel consumer thread pool size |
-| `session_worker_pool_size` | integer | `8` | Session channel thread pool size |
+| `session_worker_pool_size` | integer | `16` | Session channel thread pool size |
 
 ### transport (top-level)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `type` | string | `"rabbitmq"` | Transport type (only rabbitmq supported) |
+| `type` | string | `"rabbitmq"` | Transport type (`rabbitmq` or `local` via `LEGION_MODE=lite`) |
 | `logger_level` | string | `"info"` | Transport-level log level |
 | `prefetch` | integer | `0` | Channel prefetch count (0 = unlimited) |
+| `cluster_nodes` | array | `[]` | Additional RabbitMQ cluster nodes (merged with `host` for failover) |
+| `connection_pool_size` | integer | `1` | Number of Bunny sessions in the connection pool (1 = single session) |
+| `max_payload_bytes` | integer | `1048576` | Maximum message payload size in bytes (1 MB). Raises `PayloadTooLarge` if exceeded |
+| `region` | string | `nil` | Region identifier. When set, injects `x-legion-region` header on all published messages |
+| `management_port` | integer | `15672` | RabbitMQ Management API port (used by quorum queue policy helper) |
+
+### transport.quorum_queue_policy
+
+Opt-in quorum queue policy applied via the RabbitMQ Management API.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable idempotent quorum queue policy creation |
+| `pattern` | string | `"^legion\\."` | Queue name regex pattern for policy scope |
+| `delivery_limit` | integer | `5` | Maximum delivery attempts before dead-lettering |
+
+### transport.tenant_topology
+
+Per-tenant exchange/queue isolation. Disabled by default.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable tenant-prefixed topology |
+| `prefix_format` | string | `"t.%<tenant_id>s."` | Format string for tenant prefix (Ruby `format` syntax) |
+| `shared_exchanges` | array | `["legion.control", "legion.health", "legion.audit"]` | Exchanges that are never tenant-prefixed |
+| `auto_provision` | boolean | `true` | Auto-create tenant topology on first use |
+| `quotas` | hash | `{}` | Per-tenant rate limits (`messages_per_second`, `bytes_per_second`) |
+
+### transport.tls
+
+TLS settings for RabbitMQ connections. No defaults are defined — TLS is disabled when these keys are absent.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `tls` | boolean | — | Enable TLS for AMQP connection |
+| `tls_ca_cert` | string | — | Path to CA certificate file |
+| `tls_client_cert` | string | — | Path to client certificate file |
+| `tls_client_key` | string | — | Path to client private key file |
+| `verify_peer` | boolean | `true` | Verify server certificate (defaults to `true` when not explicitly `false`) |
+
+{: .note }
+When `Legion::Crypt::TLS` is available, TLS configuration is resolved through `Crypt::TLS.resolve` instead of these direct settings. Vault PKI mTLS is also supported via `transport.tls.vault_pki: true`.
+
+### transport.kafka
+
+Optional Kafka adapter for event streaming alongside RabbitMQ. Requires `rdkafka` gem (not included by default).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable Kafka adapter |
+| `brokers` | array | `["127.0.0.1:9092"]` | Kafka broker addresses |
+| `consumer_group` | string | `"legion"` | Default consumer group ID |
+
+#### transport.kafka.producer
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `acks` | string | `"all"` | Acknowledgement level (`all`, `1`, `0`) |
+| `retries` | integer | `3` | Number of retries on transient failure |
+| `retry_backoff_ms` | integer | `100` | Backoff between retries in milliseconds |
+| `message_timeout_ms` | integer | `30000` | Message delivery timeout in milliseconds |
+| `compression` | string | `"none"` | Compression codec (`none`, `gzip`, `snappy`, `lz4`, `zstd`) |
+| `batch_size` | integer | `100` | Maximum messages per batch |
+| `linger_ms` | integer | `5` | Delay before sending an incomplete batch |
+
+#### transport.kafka.consumer
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `poll_timeout_ms` | integer | `1000` | Poll timeout in milliseconds |
+| `max_poll_interval_ms` | integer | `300000` | Maximum time between polls before rebalance |
+| `session_timeout_ms` | integer | `30000` | Consumer session timeout |
+| `auto_offset_reset` | string | `"latest"` | Where to start reading (`latest`, `earliest`) |
+| `enable_auto_commit` | boolean | `false` | Auto-commit consumer offsets |
+| `commit_interval_messages` | integer | `100` | Commit after N messages when auto-commit is off |
+
+#### transport.kafka.admin
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `operation_timeout_ms` | integer | `10000` | Admin operation timeout |
+
+#### transport.kafka.security
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `protocol` | string | `"plaintext"` | Security protocol (`plaintext`, `ssl`, `sasl_plaintext`, `sasl_ssl`) |
+| `sasl_mechanism` | string | `""` | SASL mechanism (`PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`) |
+| `sasl_username` | string | `""` | SASL username |
+| `sasl_password` | string | `""` | SASL password |
+| `ssl_ca_cert_path` | string | `""` | Path to CA certificate |
+| `ssl_client_cert_path` | string | `""` | Path to client certificate |
+| `ssl_client_cert_key_path` | string | `""` | Path to client private key |
+
+### transport.spool
+
+Disk-based message buffer for when AMQP is unavailable. Spool is configured via method defaults, not the settings hash.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `directory` | string | `"~/.legionio/spool"` | Spool file directory |
+| `max_file_bytes` | integer | `10485760` | Maximum bytes per spool file (10 MB) |
+| `max_total_bytes` | integer | `524288000` | Maximum total spool size (500 MB) |
+| `max_files` | integer | `100` | Maximum number of spool files |
+| `max_age_seconds` | integer | `259200` | Stale file eviction age (3 days) |
 
 ---
 
@@ -179,7 +285,7 @@ Memcached `value_max_bytes` is set to 8MB by `legion-cache`. The Memcached serve
 
 ## crypt
 
-Encryption, Vault, and JWT. Gem: `legion-crypt`.
+Encryption, Vault, JWT, TLS, and SPIFFE/SVID identity. Gem: `legion-crypt`.
 
 File: `~/.legionio/settings/crypt.json`
 
@@ -188,7 +294,6 @@ File: `~/.legionio/settings/crypt.json`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `cluster_secret` | string | `nil` | Pre-shared cluster secret for message encryption |
-| `cluster_secret_timeout` | integer | `5` | Seconds to wait for cluster secret distribution |
 | `dynamic_keys` | boolean | `true` | Generate per-node RSA keypairs |
 | `save_private_key` | boolean | `true` | Persist private key to disk |
 | `read_private_key` | boolean | `true` | Read persisted private key on startup |
@@ -197,22 +302,52 @@ File: `~/.legionio/settings/crypt.json`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable HashiCorp Vault integration |
+| `enabled` | boolean | auto | Enable Vault integration (auto-detected from vault gem presence) |
 | `protocol` | string | `"http"` | Vault protocol (`http` or `https`) |
 | `address` | string | `"localhost"` | Vault server address |
 | `port` | integer | `8200` | Vault server port |
-| `token` | string | `nil` | Vault authentication token (supports `env://` URIs) |
+| `token` | string | `nil` | Vault auth token (falls back to `env://VAULT_DEV_ROOT_TOKEN_ID` or `env://VAULT_TOKEN_ID`) |
 | `renewer_time` | integer | `5` | Token renewal interval in seconds |
 | `renewer` | boolean | `true` | Enable automatic token renewal |
 | `push_cluster_secret` | boolean | `true` | Push cluster secret to Vault |
 | `read_cluster_secret` | boolean | `true` | Read cluster secret from Vault |
-| `kv_path` | string | `"legion"` | Vault KV mount path |
+| `kv_path` | string | `"legion"` | Vault KV mount path (overridable via `env://LEGION_VAULT_KV_PATH`) |
+| `vault_namespace` | string | `"legionio"` | Vault namespace |
+| `leases` | hash | `{}` | Active Vault lease tracking |
+| `clusters` | hash | `{}` | Named Vault cluster configs (same keys as `crypt.vault`) |
 
-### crypt.vault.clusters
+### crypt.vault.kerberos
+
+Kerberos authentication for Vault.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `<name>` | hash | — | Named Vault cluster config (same keys as `crypt.vault`). Enables multi-cluster Vault support. |
+| `service_principal` | string | `nil` | Kerberos service principal for Vault auth |
+| `auth_path` | string | `"auth/kerberos/login"` | Vault Kerberos auth mount path |
+
+### crypt.tls
+
+TLS configuration for inter-service communication.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable TLS |
+| `verify` | string | `"peer"` | Verification mode (`peer`, `none`) |
+| `ca` | string | `nil` | Path to CA certificate |
+| `cert` | string | `nil` | Path to client certificate |
+| `key` | string | `nil` | Path to client private key |
+
+### crypt.spiffe
+
+SPIFFE/SVID workload identity.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable SPIFFE identity |
+| `socket_path` | string | `"/tmp/spire-agent/public/api.sock"` | SPIRE agent socket path |
+| `trust_domain` | string | `"legion.internal"` | SPIFFE trust domain |
+| `workload_id` | string | `nil` | Explicit workload SPIFFE ID |
+| `renewal_window` | float | `0.5` | Fraction of SVID lifetime before renewal |
 
 ### crypt.jwt
 
@@ -229,9 +364,11 @@ File: `~/.legionio/settings/crypt.json`
 
 ## logging
 
-Structured logging. Gem: `legion-logging`.
+Structured logging with async writer, SIEM export, and PHI redaction. Gem: `legion-logging`.
 
 File: `~/.legionio/settings/logging.json`
+
+### logging (top-level)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -240,11 +377,39 @@ File: `~/.legionio/settings/logging.json`
 | `trace` | boolean | `true` | Include trace IDs in log output |
 | `backtrace_logging` | boolean | `true` | Include backtraces in error logs |
 
+### logging.async
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `buffer_size` | integer | `10000` | Async writer ring buffer size |
+
+### logging.shipper
+
+Log shipping to external SIEM/aggregation systems.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable log shipping |
+| `transport` | string | `"file"` | Transport type: `file` or `http` |
+| `batch_size` | integer | `100` | Events per batch before flush |
+| `flush_interval` | integer | `5` | Seconds between automatic flushes |
+| `levels` | array | `["warn"]` | Minimum levels to ship (lowest in array wins) |
+
+### logging.redactor
+
+Automatic PHI/PII redaction in log output.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `custom_patterns` | hash | `{}` | Custom regex patterns (`name: regex_string`) merged with built-in patterns |
+
+Built-in patterns redact: SSN, email, phone, MRN, DOB, credit card numbers, Vault tokens, JWTs, bearer tokens, and `vault://`/`lease://` URIs. Sensitive field names (`password`, `secret`, `token`, `api_key`, `authorization`) are always redacted.
+
 ---
 
 ## llm
 
-LLM integration and routing. Gem: `legion-llm`.
+LLM integration, routing, and governance pipeline. Gem: `legion-llm`.
 
 File: `~/.legionio/settings/llm.json`
 
@@ -252,51 +417,237 @@ File: `~/.legionio/settings/llm.json`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable LLM subsystem |
+| `enabled` | boolean | `true` | Enable LLM subsystem |
+| `pipeline_enabled` | boolean | `true` | Enable the 19-step governance pipeline for every LLM call |
 | `default_provider` | string | `nil` | Default provider name (e.g., `"anthropic"`, `"bedrock"`) |
-| `default_model` | string | `nil` | Default model ID (e.g., `"claude-sonnet-4-20250514"`) |
+| `default_model` | string | `nil` | Default model ID (falls back to `env://ANTHROPIC_MODEL`) |
 
 ### llm.providers.bedrock
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | Enable AWS Bedrock provider |
+| `default_model` | string | `"us.anthropic.claude-sonnet-4-6-v1"` | Default Bedrock model ID |
 | `api_key` | string | `nil` | AWS access key ID |
 | `secret_key` | string | `nil` | AWS secret access key |
 | `session_token` | string | `nil` | AWS session token (STS) |
+| `bearer_token` | string | `"env://AWS_BEARER_TOKEN_BEDROCK"` | AWS bearer token (alternative auth) |
 | `region` | string | `"us-east-2"` | AWS region |
-| `vault_path` | string | `nil` | Vault path for credential retrieval |
 
 ### llm.providers.anthropic
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | Enable Anthropic provider |
-| `api_key` | string | `nil` | Anthropic API key (supports `env://ANTHROPIC_API_KEY`) |
-| `vault_path` | string | `nil` | Vault path for credential retrieval |
+| `default_model` | string | `"claude-sonnet-4-6"` | Default Anthropic model ID |
+| `api_key` | string | `"env://ANTHROPIC_API_KEY"` | Anthropic API key |
 
 ### llm.providers.openai
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | Enable OpenAI provider |
-| `api_key` | string | `nil` | OpenAI API key |
-| `vault_path` | string | `nil` | Vault path for credential retrieval |
+| `default_model` | string | `"gpt-4o"` | Default OpenAI model ID |
+| `api_key` | string | `["env://OPENAI_API_KEY", "env://CODEX_API_KEY"]` | OpenAI API key (fallback chain) |
 
 ### llm.providers.gemini
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | Enable Google Gemini provider |
-| `api_key` | string | `nil` | Gemini API key |
-| `vault_path` | string | `nil` | Vault path for credential retrieval |
+| `default_model` | string | `"gemini-2.0-flash"` | Default Gemini model ID |
+| `api_key` | string | `"env://GEMINI_API_KEY"` | Gemini API key |
+
+### llm.providers.azure
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable Azure OpenAI provider |
+| `default_model` | string | `nil` | Azure deployment model ID |
+| `api_base` | string | `nil` | Azure OpenAI endpoint base URL |
+| `api_key` | string | `nil` | Azure API key |
+| `auth_token` | string | `nil` | Azure AD bearer token (alternative to API key) |
 
 ### llm.providers.ollama
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | boolean | `false` | Enable Ollama local provider |
+| `default_model` | string | `"llama3"` | Default Ollama model |
 | `base_url` | string | `"http://localhost:11434"` | Ollama server URL |
+
+### llm.routing
+
+Dynamic model routing with tiered provider selection and health tracking.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable dynamic routing |
+| `default_intent` | hash | `{privacy: "normal", capability: "moderate", cost: "normal"}` | Default request intent for routing decisions |
+| `rules` | array | `[]` | Custom routing rules |
+
+#### llm.routing.tiers
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `local.provider` | string | `"ollama"` | Provider for local-tier requests |
+| `fleet.queue` | string | `"llm.inference"` | AMQP queue for fleet-tier inference |
+| `fleet.timeout_seconds` | integer | `30` | Fleet request timeout |
+| `cloud.providers` | array | `["bedrock", "anthropic"]` | Ordered provider preference for cloud tier |
+
+#### llm.routing.health
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `window_seconds` | integer | `300` | Health metric sliding window |
+| `circuit_breaker.failure_threshold` | integer | `3` | Failures before opening circuit |
+| `circuit_breaker.cooldown_seconds` | integer | `60` | Seconds before retrying a tripped provider |
+| `latency_penalty_threshold_ms` | integer | `5000` | Latency above which provider is penalized |
+| `budget.daily_limit_usd` | float | `nil` | Daily spend limit (nil = unlimited) |
+| `budget.monthly_limit_usd` | float | `nil` | Monthly spend limit (nil = unlimited) |
+
+#### llm.routing.escalation
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable automatic model escalation on low quality |
+| `max_attempts` | integer | `3` | Maximum escalation attempts |
+| `quality_threshold` | integer | `50` | Minimum quality score before escalating |
+
+### llm.confidence
+
+Confidence scoring bands for LLM responses.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `bands.low` | float | `0.3` | Threshold for low confidence |
+| `bands.medium` | float | `0.5` | Threshold for medium confidence |
+| `bands.high` | float | `0.7` | Threshold for high confidence |
+| `bands.very_high` | float | `0.9` | Threshold for very high confidence |
+
+### llm.rag
+
+Retrieval-Augmented Generation context injection from Apollo knowledge store.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable RAG context injection in the pipeline |
+| `full_limit` | integer | `10` | Maximum knowledge entries at full context |
+| `compact_limit` | integer | `5` | Maximum knowledge entries at compact context |
+| `min_confidence` | float | `0.5` | Minimum confidence for included entries |
+| `utilization_compact_threshold` | float | `0.7` | Context utilization ratio to switch to compact mode |
+| `utilization_skip_threshold` | float | `0.9` | Context utilization ratio to skip RAG entirely |
+| `trivial_max_chars` | integer | `20` | Messages shorter than this are checked against trivial patterns |
+| `trivial_patterns` | array | `["hello", "hi", "hey", "ping", ...]` | Patterns that skip RAG lookup |
+
+### llm.embedding
+
+Vector embedding settings for knowledge store and RAG.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `dimension` | integer | `1024` | Target embedding dimension |
+| `enforce_dimension` | boolean | `true` | Reject embeddings that don't match target dimension |
+| `provider_fallback` | array | `["ollama", "bedrock", "openai"]` | Ordered provider preference for embedding |
+| `provider_models.ollama` | string | `"mxbai-embed-large"` | Ollama embedding model |
+| `provider_models.bedrock` | string | `"amazon.titan-embed-text-v2:0"` | Bedrock embedding model |
+| `provider_models.openai` | string | `"text-embedding-3-small"` | OpenAI embedding model |
+| `ollama_preferred` | array | `["mxbai-embed-large", "bge-large", "snowflake-arctic-embed"]` | Preferred Ollama models (checked in order) |
+
+### llm.prompt_caching
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable prompt caching |
+| `min_tokens` | integer | `1024` | Minimum prompt tokens before caching applies |
+| `response_cache.enabled` | boolean | `true` | Cache identical responses |
+| `response_cache.ttl_seconds` | integer | `300` | Response cache TTL |
+
+### llm.arbitrage
+
+Cost-optimized model selection across providers.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable cost arbitrage |
+| `prefer_cheapest` | boolean | `true` | Prefer cheapest model that meets quality floor |
+| `quality_floor` | float | `0.7` | Minimum quality score for cheaper alternatives |
+| `cost_table_refresh` | integer | `86400` | Cost table refresh interval in seconds (1 day) |
+| `cost_table` | hash | `{}` | Custom cost overrides (merged into built-in table) |
+
+### llm.batch
+
+Batch request aggregation for throughput optimization.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable request batching |
+| `window_seconds` | integer | `300` | Time window for collecting batch requests |
+| `max_batch_size` | integer | `100` | Maximum requests per batch |
+| `eligible_intents` | array | `["batch", "background", "low_priority"]` | Intent types eligible for batching |
+
+### llm.scheduling
+
+Off-peak scheduling to reduce costs during peak hours.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable peak-hour deferral |
+| `peak_hours_utc` | string | `"14-22"` | Peak hours range in UTC (14-22 = 9 AM-5 PM CT) |
+| `defer_intents` | array | `["batch", "background"]` | Intent types deferred during peak |
+| `max_defer_hours` | integer | `8` | Maximum hours to defer a request |
+
+### llm.discovery
+
+Automatic provider and model discovery at startup.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable model discovery |
+| `refresh_seconds` | integer | `60` | Discovery refresh interval |
+| `memory_floor_mb` | integer | `2048` | Minimum free memory for local model loading |
+
+### llm.gateway
+
+Optional centralized LLM gateway endpoint.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Route requests through a gateway |
+| `endpoint` | string | `nil` | Gateway URL |
+| `api_key` | string | `nil` | Gateway authentication key |
+| `timeout_seconds` | integer | `30` | Gateway request timeout |
+| `model_policy` | hash | `{}` | Per-model gateway routing policies |
+| `headers` | hash | `{}` | Additional headers for gateway requests |
+| `fallback_to_direct` | boolean | `true` | Fall back to direct provider on gateway failure |
+
+### llm.daemon
+
+Remote LLM daemon mode (run inference on a separate machine).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable daemon mode |
+| `url` | string | `nil` | Daemon endpoint URL |
+
+### llm (code-referenced keys)
+
+These keys are consumed by various modules but have no entry in the defaults hash. They must be explicitly set to take effect.
+
+| Key | Type | Code fallback | Description |
+|-----|------|---------------|-------------|
+| `shadow.enabled` | boolean | `false` | Enable shadow evaluation (dual-model comparison) |
+| `shadow.sample_rate` | float | `0.1` | Fraction of requests to shadow-evaluate |
+| `shadow.model` | string | `"gpt-4o-mini"` | Shadow evaluation model |
+| `budget.session_usd` | float | `0.0` | Per-session spend limit (0 = no limit) |
+| `cost_tracking.auto` | boolean | `true` | Auto-install cost tracking hooks |
+| `metering.auto` | boolean | `true` | Auto-install usage metering hooks |
+| `response_guards.enabled` | boolean | `false` | Enable response quality guards |
+| `rag_guard.threshold` | float | `0.7` | Minimum faithfulness score for RAG responses |
+| `rag_guard.evaluators` | array | `[:faithfulness, :rag_relevancy]` | Active RAG evaluators |
+| `structured_output.retry_on_parse_failure` | boolean | `true` | Retry on JSON parse failure |
+| `structured_output.max_retries` | integer | `2` | Maximum parse-failure retries |
+| `compressor.model` | string | `"gpt-4o-mini"` | Model for context compression |
 
 ---
 
@@ -460,24 +811,263 @@ OpenTelemetry tracing and session analytics.
 
 ## rbac
 
-Role-based access control. Gem: `legion-rbac`.
+Role-based access control with Vault-style flat policies and Entra ID integration. Gem: `legion-rbac`.
+
+File: `~/.legionio/settings/rbac.json`
+
+### rbac (top-level)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable RBAC subsystem |
-| `default_policy` | string | `"deny"` | Default policy when no rules match |
+| `enabled` | boolean | `true` | Enable RBAC subsystem |
+| `enforce` | boolean | `true` | Enforce policy checks (false = log-only mode) |
+| `default_local_role` | string | `"admin"` | Role assigned to local/unauthenticated callers |
+| `static_assignments` | array | `[]` | Static identity-to-role mappings |
+| `route_permissions` | hash | `{}` | Per-route permission overrides |
+
+### rbac.roles
+
+Four built-in roles with resource/action permissions and deny rules:
+
+| Role | Description | Cross-team |
+|------|-------------|------------|
+| `worker` | Execute assigned runners within team scope | No |
+| `supervisor` | Manage workers and schedules within team scope | No |
+| `admin` | Full access, cross-team capability | Yes |
+| `governance-observer` | Read-only visibility across all teams for audit/compliance | Yes |
+
+### rbac.entra
+
+Microsoft Entra ID (Azure AD) integration for SSO role mapping.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `tenant_id` | string | `nil` | Entra tenant ID |
+| `role_map` | hash | see below | App role to RBAC role mapping |
+| `group_map` | hash | `{}` | Group to role mapping |
+| `default_role` | string | `"worker"` | Default role for authenticated users without a mapping |
+
+Default `role_map`:
+
+```json
+{
+  "Legion.Admin": "admin",
+  "Legion.Supervisor": "supervisor",
+  "Legion.Worker": "worker",
+  "Legion.Observer": "governance-observer"
+}
+```
 
 ---
 
 ## gaia
 
-Cognitive coordination layer. Gem: `legion-gaia`.
+Cognitive coordination layer with tick/dream cycle, channels, and workflow DSL. Gem: `legion-gaia`.
+
+File: `~/.legionio/settings/gaia.json`
+
+### gaia (top-level)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable GAIA tick cycle |
-| `tick_interval` | float | `1.0` | Seconds between cognitive ticks |
-| `mode` | string | `"sentinel"` | Default tick mode: `dormant`, `dormant_active`, `sentinel`, `full_active` |
+| `enabled` | boolean | `true` | Enable GAIA tick cycle |
+| `heartbeat_interval` | integer | `1` | Seconds between cognitive ticks |
+
+### gaia.channels
+
+Channel adapters for human-agent communication.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `cli.enabled` | boolean | `true` | Enable CLI channel adapter |
+| `teams.enabled` | boolean | `false` | Enable Microsoft Teams channel adapter |
+| `slack.enabled` | boolean | `false` | Enable Slack channel adapter |
+
+### gaia.router
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `mode` | boolean | `false` | Enable cross-node message routing |
+| `allowed_worker_ids` | array | `[]` | Worker IDs permitted to route through GAIA |
+
+### gaia.session
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `persistence` | string | `"auto"` | Session persistence mode: `auto`, `always`, `never` |
+| `ttl` | integer | `86400` | Session TTL in seconds (24 hours) |
+
+### gaia.output
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `mobile_max_length` | integer | `500` | Maximum output length for mobile channels |
+| `suggest_channel_switch` | boolean | `true` | Suggest switching to a richer channel when output is truncated |
+
+### gaia.notifications
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable proactive notifications |
+| `quiet_hours.enabled` | boolean | `false` | Enable quiet hours suppression |
+| `quiet_hours.schedule` | array | `[]` | Quiet hours schedule entries |
+| `priority_override` | string | `"urgent"` | Priority level that bypasses quiet hours |
+| `delay_queue_max` | integer | `100` | Maximum queued notifications during quiet hours |
+| `max_delay` | integer | `14400` | Maximum notification delay in seconds (4 hours) |
+
+### gaia.knowledge
+
+Knowledge retrieval settings for GAIA cognitive phases.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `retrieval_limit` | integer | `5` | Maximum knowledge entries per tick |
+| `retrieval_min_confidence` | float | `0.3` | Minimum confidence for retrieved entries |
+| `memory_retrieval_limit` | integer | `10` | Maximum memory entries per retrieval |
+| `memory_audit_limit` | integer | `20` | Maximum entries for memory audit phase |
+| `memory_skip_threshold` | float | `0.8` | Context utilization above which memory retrieval is skipped |
+
+---
+
+## apollo
+
+Two-tier shared knowledge store client. Gem: `legion-apollo`.
+
+File: `~/.legionio/settings/apollo.json`
+
+### apollo (top-level)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable Apollo knowledge store |
+| `transport_mode` | string | `"auto"` | Transport mode: `auto` (detect), `amqp`, `direct` |
+| `query_timeout` | integer | `5` | Query timeout in seconds |
+| `ingest_timeout` | integer | `10` | Ingest/write timeout in seconds |
+| `max_tags` | integer | `20` | Maximum tags per knowledge entry |
+| `default_limit` | integer | `5` | Default result limit for queries |
+| `min_confidence` | float | `0.3` | Minimum confidence for returned entries |
+
+### apollo.local
+
+Local SQLite + FTS5 knowledge store (always available, no external dependencies).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable local store |
+| `retention_years` | integer | `5` | Data retention period |
+| `default_query_scope` | string | `"all"` | Default query scope: `all`, `local`, `global` |
+| `fts_candidate_multiplier` | integer | `3` | FTS candidate over-fetch multiplier for ranking |
+| `min_confidence` | float | `0.3` | Minimum confidence for local queries |
+| `default_limit` | integer | `5` | Default result limit for local queries |
+
+---
+
+## mcp
+
+Model Context Protocol server and code generation. Gem: `legion-mcp`.
+
+File: `~/.legionio/settings/mcp.json`
+
+### mcp (top-level)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `servers` | hash | `{}` | External MCP server connections |
+| `overrides` | hash | `{}` | Tool override mappings |
+| `tool_cache_ttl` | integer | `300` | Tool discovery cache TTL in seconds |
+| `connect_timeout` | integer | `10` | MCP server connection timeout |
+| `call_timeout` | integer | `30` | MCP tool call timeout |
+| `mcp.auto_expose_runners` | boolean | `false` | Auto-expose all runners as MCP tools |
+
+### mcp.codegen.self_generate
+
+Automatic code generation for missing capabilities (gap detection).
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable self-generation |
+| `cooldown_seconds` | integer | `300` | Minimum seconds between generation cycles |
+| `max_gaps_per_cycle` | integer | `5` | Maximum gaps to address per cycle |
+
+#### mcp.codegen.self_generate.tier
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `simple_max_occurrences` | integer | `10` | Occurrences threshold for simple (method-only) generation |
+| `complex_min_occurrences` | integer | `11` | Occurrences threshold for full extension generation |
+| `recurrence_window_seconds` | integer | `86400` | Window for counting gap occurrences (1 day) |
+
+#### mcp.codegen.self_generate.runner_method
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `output_dir` | string | `"~/.legionio/generated/runners"` | Output directory for generated runner methods |
+| `namespace` | string | `"Legion::Generated"` | Ruby namespace for generated code |
+
+#### mcp.codegen.self_generate.full_extension
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `output_dir` | string | `"~/.legionio/generated/extensions"` | Output directory for generated extensions |
+| `auto_bundle` | boolean | `false` | Auto-add generated gems to Bundler |
+
+#### mcp.codegen.self_generate.validation
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `syntax_check` | boolean | `true` | Validate generated code syntax |
+| `run_specs` | boolean | `true` | Run generated specs |
+| `llm_review` | boolean | `true` | LLM code review pass |
+| `max_retries` | integer | `2` | Maximum generation retries on failure |
+| `quality_gate.enabled` | boolean | `false` | Enable quality score gate |
+| `quality_gate.threshold` | float | `0.8` | Minimum quality score to accept |
+
+#### mcp.codegen.self_generate.approval
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `required` | boolean | `false` | Require human approval before activation |
+| `auto_approve_confidence` | float | `0.9` | Confidence threshold for auto-approval |
+| `auto_approve_gap_types` | array | `[]` | Gap types that auto-approve regardless of confidence |
+
+#### mcp.codegen.self_generate.corroboration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Check Apollo for existing solutions before generating |
+| `min_agents` | integer | `2` | Minimum agent corroborations to boost confidence |
+| `apollo_query_before_generate` | boolean | `true` | Query Apollo knowledge store before code generation |
+| `priority_boost_per_agent` | float | `0.15` | Confidence boost per corroborating agent |
+
+#### mcp.codegen.self_generate.github
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable GitHub PR workflow for generated code |
+| `auto_branch` | boolean | `true` | Auto-create feature branches |
+| `auto_pr` | boolean | `true` | Auto-create pull requests |
+| `auto_merge` | boolean | `false` | Auto-merge approved PRs |
+| `target_repo` | string | `nil` | Target GitHub repository |
+| `target_branch` | string | `"main"` | Target branch for PRs |
+| `pr_labels` | array | `["auto-generated", "needs-review"]` | Labels applied to generated PRs |
+| `adversarial_reviewers` | integer | `3` | Number of adversarial LLM reviewers |
+
+---
+
+## compliance
+
+Compliance framework for regulated environments. Defined in `LegionIO` main gem.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable compliance framework |
+| `classification_level` | string | `"confidential"` | Data classification level |
+| `phi_enabled` | boolean | `true` | Enable PHI (Protected Health Information) controls |
+| `pci_enabled` | boolean | `true` | Enable PCI-DSS controls |
+| `pii_enabled` | boolean | `true` | Enable PII (Personally Identifiable Information) controls |
+| `fedramp_enabled` | boolean | `true` | Enable FedRAMP controls |
+| `log_redaction` | boolean | `true` | Enable automatic log redaction |
+| `cache_phi_max_ttl` | integer | `3600` | Maximum cache TTL for PHI data in seconds (1 hour) |
 
 ---
 
@@ -507,6 +1097,7 @@ Any string value in settings can use URI schemes for dynamic resolution:
 | Scheme | Example | Description |
 |--------|---------|-------------|
 | `vault://` | `"vault://secret/data/myapp#api_key"` | Read from HashiCorp Vault KV |
+| `lease://` | `"lease://rabbitmq#username"` | Dynamic Vault lease credential (auto-renewed) |
 | `env://` | `"env://RABBITMQ_PASSWORD"` | Read from environment variable |
 | plain string | `"my-value"` | Used as-is |
 
@@ -561,7 +1152,7 @@ Many extensions define their own settings sections. These are configured under t
 | `mesh.silence_timeout` | integer | `30` | Seconds before marking an agent offline |
 | `mesh.max_hops` | integer | `3` | Maximum message routing hops |
 
-### lex-apollo
+### lex-apollo (extension overrides)
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -569,6 +1160,9 @@ Many extensions define their own settings sections. These are configured under t
 | `apollo.corroboration_boost` | float | `0.3` | Confidence boost on corroboration |
 | `apollo.decay_rate` | float | `0.998` | Hourly confidence decay multiplier |
 | `apollo.novelty_threshold` | float | `0.3` | Minimum novelty for write path |
+
+{: .note }
+See also the [apollo](#apollo) top-level section for client settings.
 
 ---
 

--- a/settings.md
+++ b/settings.md
@@ -373,9 +373,22 @@ File: `~/.legionio/settings/logging.json`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `level` | string | `"info"` | Log level: `debug`, `info`, `warn`, `error`, `fatal` |
-| `location` | string | `"stdout"` | Log destination: `stdout`, `stderr`, or file path |
+| `format` | string | `"text"` | Output format: `text` or `json` (structured) |
+| `log_file` | string | `"./legionio/logs/legion.log"` | File log destination path |
+| `log_stdout` | boolean | `true` | Also log to stdout |
 | `trace` | boolean | `true` | Include trace IDs in log output |
-| `backtrace_logging` | boolean | `true` | Include backtraces in error logs |
+| `async` | boolean | `true` | Enable async log writer |
+| `include_pid` | boolean | `false` | Include process ID in log output |
+
+### logging.transport
+
+Forward log events over AMQP for centralized collection.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable AMQP log forwarding |
+| `forward_logs` | boolean | `true` | Forward standard log events |
+| `forward_exceptions` | boolean | `true` | Forward exception events |
 
 ### logging.async
 
@@ -394,6 +407,9 @@ Log shipping to external SIEM/aggregation systems.
 | `batch_size` | integer | `100` | Events per batch before flush |
 | `flush_interval` | integer | `5` | Seconds between automatic flushes |
 | `levels` | array | `["warn"]` | Minimum levels to ship (lowest in array wins) |
+| `endpoint` | string | `nil` | HTTP transport endpoint URL (Splunk HEC, etc.) |
+| `auth_token` | string | `nil` | HTTP transport auth token (Bearer or Splunk) |
+| `file.path` | string | `"/var/log/legion/siem.log"` | File transport output path |
 
 ### logging.redactor
 
@@ -1068,6 +1084,84 @@ Compliance framework for regulated environments. Defined in `LegionIO` main gem.
 | `fedramp_enabled` | boolean | `true` | Enable FedRAMP controls |
 | `log_redaction` | boolean | `true` | Enable automatic log redaction |
 | `cache_phi_max_ttl` | integer | `3600` | Maximum cache TTL for PHI data in seconds (1 hour) |
+
+---
+
+## absorbers
+
+Pattern-matched content acquisition from external sources. Defined in `legion-settings`.
+
+File: `~/.legionio/settings/absorbers.json`
+
+### absorbers (top-level)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable absorber subsystem |
+| `max_depth` | integer | `5` | Maximum recursion depth for content traversal |
+
+### absorbers.sources.meetings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Absorb meeting transcripts and recordings |
+| `include_chat` | boolean | `true` | Include meeting chat messages |
+| `include_files` | boolean | `true` | Include shared files from meetings |
+| `retention_days` | integer | `90` | Days to retain absorbed meeting content |
+| `min_duration_min` | integer | `5` | Minimum meeting duration to absorb (minutes) |
+
+### absorbers.sources.email_inbox
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Absorb email inbox content |
+| `folder` | string | `"inbox"` | Email folder to monitor |
+| `max_age_days` | integer | `30` | Maximum email age to absorb |
+
+### absorbers.sources.github
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Absorb GitHub events |
+| `events` | array | `["pull_request", "issues"]` | GitHub event types to absorb |
+
+### absorbers.sources.files
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Absorb local files |
+| `watch_dirs` | array | `[]` | Directories to watch for changes |
+| `extensions` | array | `["pdf", "docx", "txt", "md", "pptx", "rtf"]` | File extensions to absorb |
+
+---
+
+## network
+
+Network monitoring and health checks.
+
+### network.watchdog
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable network watchdog |
+| `failure_threshold` | integer | `5` | Consecutive failures before pausing actors |
+| `check_interval` | integer | `15` | Seconds between health checks |
+
+When the failure threshold is reached, all actors are paused. On recovery, `Legion.reload` is triggered to restore connections.
+
+---
+
+## security
+
+Security settings for mTLS and identity.
+
+### security.mtls
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable mTLS certificate rotation |
+| `vault_pki_path` | string | `"pki/issue/legion-internal"` | Vault PKI issue path |
+| `cert_ttl` | string | `"24h"` | Certificate TTL |
 
 ---
 

--- a/settings.md
+++ b/settings.md
@@ -1,6 +1,6 @@
 ---
 title: Settings Reference
-nav_order: 4
+nav_order: 9
 description: "Complete reference for every configurable setting in LegionIO and its core gems."
 ---
 


### PR DESCRIPTION
- update all gem versions, tick/dream phase counts, and LLM model versions
- add new pipeline.md page documenting 19-step LLM governance pipeline
- expand architecture.md with Apollo two-tier store, absorbers, and pipeline
- add compliance, audit, and resilience sections to enterprise.md
- add mesh networking, absorbers, and new extensions to extensions.md
- bump versions in quickstart guides
- fix nav_order conflicts across all pages

## What

Brief description of the change.

## Why

What problem does this solve or what feature does it add?

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] No new security concerns introduced
